### PR TITLE
Remove mongoengine stats from debug toolbar

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,7 +50,6 @@ class DevConfig(Config):
         'flask_debugtoolbar.panels.template.TemplateDebugPanel',
         'flask_debugtoolbar.panels.logger.LoggingPanel',
         'flask_debugtoolbar.panels.profiler.ProfilerDebugPanel',
-        'flask.ext.mongoengine.panels.MongoDebugPanel',
         'flask_debug_api.BrowseAPIPanel'
     ]
 

--- a/onelove/__init__.py
+++ b/onelove/__init__.py
@@ -25,6 +25,7 @@ class OneLove(object):
                 setattr(self, k, v)
 
     api = None
+    api_extension = None
     app = None
     blueprint = None
     collect = Collect()
@@ -88,7 +89,7 @@ class OneLove(object):
             from flask_debugtoolbar import DebugToolbarExtension
             from flask_debug_api import DebugAPIExtension
             self.toolbar = DebugToolbarExtension(self.app)
-            self.toolbar = DebugAPIExtension(self.app)
+            self.api_extension = DebugAPIExtension(self.app)
 
         self.socketio = SocketIO(self.app, logger=True, async_mode='gevent')
         self.app.onelove = self


### PR DESCRIPTION
This should be temporary, as mongoengine in FDT makes swagger page empty